### PR TITLE
Fix load priority

### DIFF
--- a/SaneEconomyCore/src/main/resources/plugin.yml
+++ b/SaneEconomyCore/src/main/resources/plugin.yml
@@ -2,7 +2,8 @@ name: SaneEconomy
 author: AppleDash
 main: org.appledash.saneeconomy.SaneEconomy
 version: 0.10.1
-loadbefore: [Vault]
+load: STARTUP
+softdepend: [Vault]
 commands:
   balance:
     aliases: [bal, money]


### PR DESCRIPTION
Hello

This is a patch to fix the loading priority of SaneEconomy. I saw that there has been an attempt at fixing it here: 97709b0565290f026f5e3b27e77479edb3a1b980. By removing the softdepend line in this commit, SaneEconomy gets loaded at a different point, so it would have fixed the problem for some plugins. Unfortunately there's still plugins that gets loaded before SaneEconomy and is then unable to connect to it through Vault. I've come across multiple discussions on this and I hope this pull request will solve it once and for all.

The line 'loadbefore: [Vault]' is according to the [BukkitWiki](http://wiki.bukkit.org/Plugin_YAML) "A list of plugins should be loaded after your plugin." And so the first change is to remove this line as Vault should not be loaded after SaneEconomy but before.

The line 'load: STARTUP' is added by recommendation from Sleaker in this [vault discussion](https://github.com/MilkBowl/Vault/issues/650#issuecomment-204074254). This ensures that SaneEconomy gets loaded around the same time as Vault, before any other plugin. (Vault also has it's load set to STARTUP)

Finally the line 'softdepend: [Vault]' is added to make sure that SaneEconomy gets loaded after Vault. This ensures that SaneEconomy can find Vault. The softdepend (instead of depend) also ensures that SaneEconomy can run without Vault.

After this change you should see that SaneEconomy gets completely loaded straight after Vault and before any other plugin.